### PR TITLE
Turn around dependencies in VOIP_EXT_LIBS as voip_toolbox depends on rtaudio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,9 @@ add_subdirectory( ext/rtaudio )
 add_subdirectory( toolbox )
 
 if( ${CMAKE_SYSTEM_NAME} STREQUAL Windows)
-	set( VOIP_EXT_LIBS    rtaudio_static voip_toolbox ws2_32)
+	set( VOIP_EXT_LIBS voip_toolbox rtaudio_static ws2_32)
 else()
-	set( VOIP_EXT_LIBS    rtaudio voip_toolbox)
+	set( VOIP_EXT_LIBS voip_toolbox rtaudio)
 endif()
 
 if( ${VOIP_BUILD_DEMOS} )


### PR DESCRIPTION
This bug prevents building the applications in `demo` using GCC 5.4.0 on Ubuntu Xenial.

See also http://stackoverflow.com/a/1519021